### PR TITLE
A few improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,14 +14,15 @@ Usage
 
 ::
 
-    Usage: format-imports.py [options]
+    usage: format-imports.py [-h] [-a APPLICATIONS [APPLICATIONS ...]]
+                         [-s STDLIB_FILES [STDLIB_FILES ...]]
 
     Groups, sorts, and formats import statements.
 
-    Options:
-    -h, --help            show this help message and exit
-    -a APPLICATION, --application=APPLICATION
-    -s STDLIB_FILES, --stdlib-file=STDLIB_FILES
+    optional arguments:
+      -h, --help            show this help message and exit
+      -a APPLICATIONS [APPLICATIONS ...], --application APPLICATIONS [APPLICATIONS ...]
+      -s STDLIB_FILES [STDLIB_FILES ...], --stdlib-file STDLIB_FILES [STDLIB_FILES ...]
                             File(s) containing additional module names to add to
                             the standard library set.
 

--- a/bin/format-imports.py
+++ b/bin/format-imports.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 import ast
-import os
 import logging
 import string
 import sys
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 from pkg_resources import resource_stream
 
@@ -13,22 +12,21 @@ from importformatter import ImportCollector
 
 logging.basicConfig()
 
-parser = OptionParser(description='Groups, sorts, and formats import statements.')
-parser.add_option('-a', '--application', default=None)
-parser.add_option('-s', '--stdlib-file', action='append', dest='stdlib_files', default=[],
+parser = ArgumentParser(description='Groups, sorts, and formats import statements.')
+parser.add_argument('-a', '--application', dest='applications', nargs='+', default=[])
+parser.add_argument('-s', '--stdlib-file', dest='stdlib_files', nargs='+',
     help='File(s) containing additional module names to add to the standard library set.')
-(options, args) = parser.parse_args()
+options = parser.parse_args()
 
 stdlib = set()
 
 def add_libraries(stream):
     stdlib.update(map(string.strip, stream.readlines()))
 
-if not options.stdlib_files:
-    add_libraries(resource_stream('importformatter', 'stdlib.txt'))
-else:
+add_libraries(resource_stream('importformatter', 'stdlib.txt'))
+if options.stdlib_files:
     map(add_libraries, map(file, options.stdlib_files))
 
-visitor = ImportCollector(options.application, stdlib)
+visitor = ImportCollector(options.applications, stdlib)
 visitor.visit(ast.parse(sys.stdin.read()))
 print visitor

--- a/importformatter/__init__.py
+++ b/importformatter/__init__.py
@@ -3,8 +3,6 @@ Groups, sorts, and prints formatted imports statements.
 """
 import ast
 import logging
-import operator
-import os
 from collections import defaultdict
 
 
@@ -48,10 +46,10 @@ SPECIAL_MODULES = frozenset((
 
 
 class ImportCollector(ast.NodeVisitor):
-    def __init__(self, name, stdlib, *args, **kwargs):
+    def __init__(self, names, stdlib, *args, **kwargs):
         super(ImportCollector, self).__init__(*args, **kwargs)
-        self.name = name
-        if self.name is None:
+        self.names = names
+        if not self.names:
             logger.warning('No application name provided')
 
         self.stdlib = stdlib
@@ -76,7 +74,7 @@ class ImportCollector(ast.NodeVisitor):
         return name in self.stdlib
 
     def is_application(self, name):
-        return self.name is not None and name.startswith(self.name)
+        return any(map(lambda n: name.startswith(n), self.names))
 
     def visit_Import(self, node):
         for alias in node.names:


### PR DESCRIPTION
- multiple applications
- argparse instead of deprecated optparse
- std is extended, not overidden
- removed unnecessary imports

Hi we have a legacy app which contains multiple app packages (in the middle package renaming).
We needed it so I updated for mainly multiple applications option but also did small improvements.
